### PR TITLE
rfc5731: Optional authInfo for domain:info

### DIFF
--- a/src/AfriCC/EPP/Frame/Command/Info/Domain.php
+++ b/src/AfriCC/EPP/Frame/Command/Info/Domain.php
@@ -35,6 +35,10 @@ class Domain extends InfoCommand
     
     public function setAuthInfo($pw, $roid = null)
     {
-        $this->set('domain:authInfo/domain:pw', $pw);
+        $node = $this->set('domain:authInfo/domain:pw', $pw);
+
+        if ($roid !== null) {
+            $node->setAttribute('roid', $roid);
+        }
     }
 }

--- a/src/AfriCC/EPP/Frame/Command/Info/Domain.php
+++ b/src/AfriCC/EPP/Frame/Command/Info/Domain.php
@@ -32,4 +32,9 @@ class Domain extends InfoCommand
 
         $this->set(sprintf('domain:name[@hosts=\'%s\']', $return), $domain);
     }
+    
+    public function setAuthInfo($pw, $roid = null)
+    {
+        $this->set('domain:authInfo/domain:pw', $pw);
+    }
 }


### PR DESCRIPTION
RFC 5731 states that domain:info should allow for optional authInfo element. This PR adds tiny little function just for that :wink:
