### PR TITLE
Fixes #12: Gradually implement proper response handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
     - php: 7.0
     - php: 5.6
     - php: 5.5
-    - php: hhvm
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,10 @@ if (!($response instanceof Response)) {
     exit(1);
 }
 
-echo $response->code() . PHP_EOL;
-echo $response->message() . PHP_EOL;
+$result = $response->results()[0];
+
+echo $result->code() . PHP_EOL;
+echo $result->message() . PHP_EOL;
 echo $response->clientTransactionId() . PHP_EOL;
 echo $response->serverTransactionId() . PHP_EOL;
 $data = $response->data();

--- a/src/AfriCC/EPP/DOM/DOMElement.php
+++ b/src/AfriCC/EPP/DOM/DOMElement.php
@@ -11,10 +11,10 @@
 
 namespace AfriCC\EPP\DOM;
 
-use DOMElement as DOMElementLegacy;
+use DOMElement as PHP_DOMElement;
 use DOMNodeList;
 
-class DOMElement extends DOMElementLegacy
+class DOMElement extends PHP_DOMElement
 {
     public function hasChildNodes()
     {

--- a/src/AfriCC/EPP/DOM/DOMTools.php
+++ b/src/AfriCC/EPP/DOM/DOMTools.php
@@ -11,7 +11,7 @@
 
 namespace AfriCC\EPP\DOM;
 
-use \DOMElement;
+use DOMElement as PHP_DOMElement;
 
 class DOMTools
 {
@@ -25,7 +25,7 @@ class DOMTools
      * contain duplicate information (forex: ipType).
      */
     public static function nodeToArray(
-        DOMElement $node,
+        PHP_DOMElement $node,
         $forceArrayKeys = ['hostAttr', 'hostObj', 'street', 'hostAddr'],
         $ignoreAttributeKeys = ['hostAddr']
     ) {

--- a/src/AfriCC/EPP/DOM/DOMTools.php
+++ b/src/AfriCC/EPP/DOM/DOMTools.php
@@ -28,8 +28,7 @@ class DOMTools
         DOMElement $node,
         $forceArrayKeys = ['hostAttr', 'hostObj', 'street', 'hostAddr'],
         $ignoreAttributeKeys = ['hostAddr']
-    )
-    {
+    ) {
         $tmp = [];
         foreach ($node->childNodes as $each) {
             if ($each->nodeType !== XML_ELEMENT_NODE) {

--- a/src/AfriCC/EPP/DOM/DOMTools.php
+++ b/src/AfriCC/EPP/DOM/DOMTools.php
@@ -11,7 +11,7 @@
 
 namespace AfriCC\EPP\DOM;
 
-use DOMElement;
+use \DOMElement;
 
 class DOMTools
 {

--- a/src/AfriCC/EPP/DOM/DOMTools.php
+++ b/src/AfriCC/EPP/DOM/DOMTools.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of the php-epp2 library.
+ *
+ * (c) Gunter Grodotzki <gunter@afri.cc>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace AfriCC\EPP\DOM;
+
+use DOMElement;
+
+class DOMTools
+{
+    /**
+     * transform epp style DOMElement to a php-array
+     *
+     * @param DOMElement $node
+     * @param array $forceArrayKeys force certain tags into an array that are
+     * expected to be iterated (forex: street).
+     * @param array $ignoreAttributeKeys ignore certain attributes as they
+     * contain duplicate information (forex: ipType).
+     */
+    public static function nodeToArray(
+        DOMElement $node,
+        $forceArrayKeys = ['hostAttr', 'hostObj', 'street', 'hostAddr'],
+        $ignoreAttributeKeys = ['hostAddr']
+    )
+    {
+        $tmp = [];
+        foreach ($node->childNodes as $each) {
+            if ($each->nodeType !== XML_ELEMENT_NODE) {
+                continue;
+            }
+
+            // if node only has a type attribute lets distinguish them directly
+            // and then ignore the attribtue
+            if ($each->hasAttribute('type')) {
+                $key = $each->localName . '@' . $each->getAttribute('type');
+                $ignore_attributes = true;
+            } else {
+                $key = $each->localName;
+                $ignore_attributes = false;
+            }
+
+            // in case of special keys, always create array
+            if (in_array($key, $forceArrayKeys)) {
+                $current = &$tmp[$key][];
+                end($tmp[$key]);
+                $insert_key = key($tmp[$key]);
+            }
+            // if key already exists, dynamically create an array
+            elseif (isset($tmp[$key])) {
+                if (!is_array($tmp[$key]) || !isset($tmp[$key][0])) {
+                    $tmp[$key] = [$tmp[$key]];
+                }
+                $current = &$tmp[$key][];
+                end($tmp[$key]);
+                $insert_key = key($tmp[$key]);
+            }
+            // key was not yet set, so lets start off with a string
+            else {
+                $current = &$tmp[$key];
+                $insert_key = null;
+            }
+
+            if ($each->hasChildNodes()) {
+                $current = static::nodeToArray($each, $forceArrayKeys, $ignoreAttributeKeys);
+            } else {
+                $current = $each->nodeValue;
+
+                if (!$ignore_attributes && !in_array($each->localName, $ignoreAttributeKeys) && $each->hasAttributes()) {
+                    foreach ($each->attributes as $attr) {
+
+                        // single attribute with empty node, use the attr-value directly
+                        if ($each->localName === 'status' || ($each->attributes->length === 1 && $each->nodeValue === '')) {
+                            $current = $attr->nodeValue;
+                            break;
+                        }
+
+                        if ($insert_key) {
+                            if (isset($tmp['@' . $key][$attr->nodeName]) && !is_array($tmp['@' . $key][$attr->nodeName])) {
+                                $tmp['@' . $key][$attr->nodeName] = [$tmp['@' . $key][$attr->nodeName]];
+                            }
+                            $tmp['@' . $key][$attr->nodeName][$insert_key] = $attr->nodeValue;
+                        } else {
+                            $tmp['@' . $key][$attr->nodeName] = $attr->nodeValue;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $tmp;
+    }
+}

--- a/src/AfriCC/EPP/Frame/Command/Transfer/Domain.php
+++ b/src/AfriCC/EPP/Frame/Command/Transfer/Domain.php
@@ -26,7 +26,7 @@ class Domain extends TransferCommand
     public function setDomain($domain)
     {
         if (!Validator::isHostname($domain)) {
-            throw new Exception(sprintf('%s is not a valid domain name'));
+            throw new Exception(sprintf('%s is not a valid domain name', $domain));
         }
 
         $this->set('domain:name', $domain);

--- a/src/AfriCC/EPP/Frame/Response.php
+++ b/src/AfriCC/EPP/Frame/Response.php
@@ -12,8 +12,8 @@
 namespace AfriCC\EPP\Frame;
 
 use AfriCC\EPP\AbstractFrame;
+use AfriCC\EPP\DOM\DOMTools;
 use AfriCC\EPP\Frame\Response\Result;
-use DOMNode;
 use DOMNodeList;
 
 /**
@@ -21,31 +21,6 @@ use DOMNodeList;
  */
 class Response extends AbstractFrame
 {
-    /**
-     * nodeToArray force array values for the following tags. Usually the upper
-     * level will expect them as an array to traverse. Otherwise, if only one
-     * value exists it will be converted directly to a string
-     *
-     * @var array
-     */
-    protected $n2a_force_array = [
-        'hostAttr' => true,
-        'hostObj' => true,
-        'street' => true,
-        'hostAddr' => true,
-    ];
-
-    /**
-     * nodeToArray ignore conversion of following attributes. Usually because
-     * the information is redundant or useless (like the definition of IP types
-     * which should be done on the higher level)
-     *
-     * @var array
-     */
-    protected $n2a_ignore_attr = [
-        'hostAddr' => true,
-    ];
-
     public function results()
     {
         $results = [];
@@ -103,84 +78,15 @@ class Response extends AbstractFrame
         if ($nodes === false || !($nodes instanceof DOMNodeList) || $nodes->length === 0 || !$nodes->item(0)->hasChildNodes()) {
             $data = [];
         } else {
-            $data = $this->nodeToArray($nodes->item(0));
+            $data = DOMTools::nodeToArray($nodes->item(0));
         }
 
         // check for extension data
         $nodes = $this->get('//epp:epp/epp:response/epp:extension');
         if ($nodes !== false && $nodes instanceof DOMNodeList && $nodes->length > 0 && $nodes->item(0)->hasChildNodes()) {
-            $data = array_merge_recursive($data, $this->nodeToArray($nodes->item(0)));
+            $data = array_merge_recursive($data, DOMTools::nodeToArray($nodes->item(0)));
         }
 
         return $data;
-    }
-
-    private function nodeToArray(DOMNode $node)
-    {
-        $tmp = [];
-        foreach ($node->childNodes as $each) {
-            if ($each->nodeType !== XML_ELEMENT_NODE) {
-                continue;
-            }
-
-            // if node only has a type attribute lets distinguish them directly
-            // and then ignore the attribtue
-            if ($each->hasAttribute('type')) {
-                $key = $each->localName . '@' . $each->getAttribute('type');
-                $ignore_attributes = true;
-            } else {
-                $key = $each->localName;
-                $ignore_attributes = false;
-            }
-
-            // in case of special keys, always create array
-            if (isset($this->n2a_force_array[$key])) {
-                $current = &$tmp[$key][];
-                end($tmp[$key]);
-                $insert_key = key($tmp[$key]);
-            }
-            // if key already exists, dynamically create an array
-            elseif (isset($tmp[$key])) {
-                if (!is_array($tmp[$key]) || !isset($tmp[$key][0])) {
-                    $tmp[$key] = [$tmp[$key]];
-                }
-                $current = &$tmp[$key][];
-                end($tmp[$key]);
-                $insert_key = key($tmp[$key]);
-            }
-            // key was not yet set, so lets start off with a string
-            else {
-                $current = &$tmp[$key];
-                $insert_key = null;
-            }
-
-            if ($each->hasChildNodes()) {
-                $current = $this->nodeToArray($each);
-            } else {
-                $current = $each->nodeValue;
-
-                if (!$ignore_attributes && !isset($this->n2a_ignore_attr[$each->localName]) && $each->hasAttributes()) {
-                    foreach ($each->attributes as $attr) {
-
-                        // single attribute with empty node, use the attr-value directly
-                        if ($each->localName === 'status' || ($each->attributes->length === 1 && $each->nodeValue === '')) {
-                            $current = $attr->nodeValue;
-                            break;
-                        }
-
-                        if ($insert_key) {
-                            if (isset($tmp['@' . $key][$attr->nodeName]) && !is_array($tmp['@' . $key][$attr->nodeName])) {
-                                $tmp['@' . $key][$attr->nodeName] = [$tmp['@' . $key][$attr->nodeName]];
-                            }
-                            $tmp['@' . $key][$attr->nodeName][$insert_key] = $attr->nodeValue;
-                        } else {
-                            $tmp['@' . $key][$attr->nodeName] = $attr->nodeValue;
-                        }
-                    }
-                }
-            }
-        }
-
-        return $tmp;
     }
 }

--- a/src/AfriCC/EPP/Frame/Response/MessageQueue.php
+++ b/src/AfriCC/EPP/Frame/Response/MessageQueue.php
@@ -22,7 +22,7 @@ class MessageQueue extends ResponseFrame
 
     public function queueCount()
     {
-        return $this->get('//epp:epp/epp:response/epp:msgQ/@count');
+        return (int) $this->get('//epp:epp/epp:response/epp:msgQ/@count');
     }
 
     public function queueMessage()

--- a/src/AfriCC/EPP/Frame/Response/Result.php
+++ b/src/AfriCC/EPP/Frame/Response/Result.php
@@ -11,8 +11,8 @@
 
 namespace AfriCC\EPP\Frame\Response;
 
+use AfriCC\EPP\DOM\DOMTools;
 use DOMElement;
-use DOMNode;
 
 class Result
 {
@@ -76,7 +76,7 @@ class Result
                 continue;
             }
 
-            switch($each->localName) {
+            switch ($each->localName) {
                 case 'msg':
                     $this->msg = $each->nodeValue;
                     if ($each->hasAttribute('lang')) {
@@ -85,84 +85,16 @@ class Result
                     break;
 
                 case 'value':
-                    $this->values = $this->nodeToArray($each);
+                    $this->values = array_merge_recursive($this->values, DOMTools::nodeToArray($each));
                     break;
 
                 case 'extValue':
+                    $this->extValues = array_merge_recursive($this->extValues, DOMTools::nodeToArray($each));
                     break;
 
                 default:
                     break;
             }
         }
-    }
-
-    private function nodeToArray(DOMNode $node)
-    {
-        $tmp = [];
-        foreach ($node->childNodes as $each) {
-            if ($each->nodeType !== XML_ELEMENT_NODE) {
-                continue;
-            }
-
-            // if node only has a type attribute lets distinguish them directly
-            // and then ignore the attribtue
-            if ($each->hasAttribute('type')) {
-                $key = $each->localName . '@' . $each->getAttribute('type');
-                $ignore_attributes = true;
-            } else {
-                $key = $each->localName;
-                $ignore_attributes = false;
-            }
-
-            // in case of special keys, always create array
-            if (isset($this->n2a_force_array[$key])) {
-                $current = &$tmp[$key][];
-                end($tmp[$key]);
-                $insert_key = key($tmp[$key]);
-            }
-            // if key already exists, dynamically create an array
-            elseif (isset($tmp[$key])) {
-                if (!is_array($tmp[$key]) || !isset($tmp[$key][0])) {
-                    $tmp[$key] = [$tmp[$key]];
-                }
-                $current = &$tmp[$key][];
-                end($tmp[$key]);
-                $insert_key = key($tmp[$key]);
-            }
-            // key was not yet set, so lets start off with a string
-            else {
-                $current = &$tmp[$key];
-                $insert_key = null;
-            }
-
-            if ($each->hasChildNodes()) {
-                $current = $this->nodeToArray($each);
-            } else {
-                $current = $each->nodeValue;
-
-                if (!$ignore_attributes && !isset($this->n2a_ignore_attr[$each->localName]) && $each->hasAttributes()) {
-                    foreach ($each->attributes as $attr) {
-
-                        // single attribute with empty node, use the attr-value directly
-                        if ($each->localName === 'status' || ($each->attributes->length === 1 && $each->nodeValue === '')) {
-                            $current = $attr->nodeValue;
-                            break;
-                        }
-
-                        if ($insert_key) {
-                            if (isset($tmp['@' . $key][$attr->nodeName]) && !is_array($tmp['@' . $key][$attr->nodeName])) {
-                                $tmp['@' . $key][$attr->nodeName] = [$tmp['@' . $key][$attr->nodeName]];
-                            }
-                            $tmp['@' . $key][$attr->nodeName][$insert_key] = $attr->nodeValue;
-                        } else {
-                            $tmp['@' . $key][$attr->nodeName] = $attr->nodeValue;
-                        }
-                    }
-                }
-            }
-        }
-
-        return $tmp;
     }
 }

--- a/src/AfriCC/EPP/Frame/ResponseFactory.php
+++ b/src/AfriCC/EPP/Frame/ResponseFactory.php
@@ -47,7 +47,7 @@ class ResponseFactory
             // ok now we can create an object according to the response-frame
             $frame_type = strtolower($node->localName);
             if ($frame_type === 'response') {
-                // check if it is a message queue
+                // check if it is a message queue @todo this should go into the response object!
                 $results = $xpath->query('//epp:epp/epp:response/epp:msgQ');
                 if ($results->length > 0) {
                     return new \AfriCC\EPP\Frame\Response\MessageQueue($xml);

--- a/tests/EPP/Frame/Command/Create/DomainCreateTest.php
+++ b/tests/EPP/Frame/Command/Create/DomainCreateTest.php
@@ -13,6 +13,7 @@ class DomainCreateTest extends TestCase
         $frame = new Domain();
         $frame->setDomain(TEST_DOMAIN);
         $frame->setPeriod('1y');
+        $frame->addHostObj('ns3.' . TEST_DOMAIN);
         $frame->addHostAttr('ns2.' . TEST_DOMAIN);
         $frame->addHostAttr('ns1.' . TEST_DOMAIN, [
             '8.8.8.8',
@@ -21,6 +22,7 @@ class DomainCreateTest extends TestCase
         $frame->setRegistrant('C001');
         $frame->setAdminContact('C002');
         $frame->setTechContact('C003');
+        $frame->setBillingContact('C004');
         $auth = $frame->setAuthInfo();
 
         $this->assertXmlStringEqualsXmlString(
@@ -32,6 +34,7 @@ class DomainCreateTest extends TestCase
                     <domain:name>' . TEST_DOMAIN . '</domain:name>
                     <domain:period unit="y">1</domain:period>
                     <domain:ns>
+                      <domain:hostObj>ns3.' . TEST_DOMAIN . '</domain:hostObj>
                       <domain:hostAttr>
                         <domain:hostName>ns2.' . TEST_DOMAIN . '</domain:hostName>
                       </domain:hostAttr>
@@ -44,6 +47,7 @@ class DomainCreateTest extends TestCase
                     <domain:registrant>C001</domain:registrant>
                     <domain:contact type="admin">C002</domain:contact>
                     <domain:contact type="tech">C003</domain:contact>
+                    <domain:contact type="billing">C004</domain:contact>
                     <domain:authInfo>
                       <domain:pw>' . $auth . '</domain:pw>
                     </domain:authInfo>

--- a/tests/EPP/Frame/Command/Create/DomainCreateTest.php
+++ b/tests/EPP/Frame/Command/Create/DomainCreateTest.php
@@ -3,6 +3,7 @@
 namespace AfriCC\Tests\EPP\Frame\Command\Create;
 
 use AfriCC\EPP\Frame\Command\Create\Domain;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 class DomainCreateTest extends TestCase
@@ -53,5 +54,37 @@ class DomainCreateTest extends TestCase
             ',
             (string) $frame
         );
+    }
+
+    public function testDomainCreateFrameInvalidDomain()
+    {
+        $frame = new Domain();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->setDomain('invalid_domain');
+        } else {
+            try {
+                $frame->setDomain('invalid_domain');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
+    }
+
+    public function testDomainCreateFrameInvalidHostObj()
+    {
+        $frame = new Domain();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->addHostObj('invalid_domain');
+        } else {
+            try {
+                $frame->addHostObj('invalid_domain');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
     }
 }

--- a/tests/EPP/Frame/Command/Info/ContactInfoTest.php
+++ b/tests/EPP/Frame/Command/Info/ContactInfoTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Frame\Command\Info;
+
+use AfriCC\EPP\Frame\Command\Info\Contact;
+use PHPUnit\Framework\TestCase;
+
+class ContactInfoTest extends TestCase
+{
+    public function testContactInfoFrame()
+    {
+        $frame = new Contact();
+        $frame->setId('C001');
+        $frame->setAuthInfo('password');
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <info>
+                  <contact:info xmlns:contact="urn:ietf:params:xml:ns:contact-1.0">
+                    <contact:id>C001</contact:id>
+                    <contact:authInfo>
+                      <contact:pw>password</contact:pw>
+                    </contact:authInfo>
+                  </contact:info>
+                </info>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+}

--- a/tests/EPP/Frame/Command/Info/DomainInfoTest.php
+++ b/tests/EPP/Frame/Command/Info/DomainInfoTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Frame\Command\Info;
+
+use AfriCC\EPP\Frame\Command\Info\Domain;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class DomainInfoTest extends TestCase
+{
+    public function testDomainInfoFrame()
+    {
+        $frame = new Domain();
+        $frame->setDomain(TEST_DOMAIN);
+        $frame->setAuthInfo('password');
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <info>
+                  <domain:info xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                    <domain:name hosts="all">epptest.org</domain:name>
+                    <domain:authInfo>
+                      <domain:pw>password</domain:pw>
+                    </domain:authInfo>
+                  </domain:info>
+                </info>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+
+    public function testDomainInfoFrameInvalidDomain()
+    {
+        $frame = new Domain();
+        $frame->setAuthInfo('foo', 'bar');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->setDomain('invalid_domain');
+        } else {
+            try {
+                $frame->setDomain('invalid_domain');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
+    }
+
+    public function testDomainInfoFrameInvalidReturn()
+    {
+        $frame = new Domain();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->setDomain(TEST_DOMAIN, 'foo');
+        } else {
+            try {
+                $frame->setDomain(TEST_DOMAIN, 'foo');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
+    }
+}

--- a/tests/EPP/Frame/Command/Info/HostInfoTest.php
+++ b/tests/EPP/Frame/Command/Info/HostInfoTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Frame\Command\Info;
+
+use AfriCC\EPP\Frame\Command\Info\Host;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class HostInfoTest extends TestCase
+{
+    public function testHostInfoFrame()
+    {
+        $frame = new Host();
+        $frame->setHost('ns1.' . TEST_DOMAIN);
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <info>
+                  <host:info xmlns:host="urn:ietf:params:xml:ns:host-1.0">
+                    <host:name>ns1.' . TEST_DOMAIN . '</host:name>
+                  </host:info>
+                </info>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+
+    public function testHostInfoFrameInvalidHost()
+    {
+        $frame = new Host();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->setHost('invalid_domain');
+        } else {
+            try {
+                $frame->setHost('invalid_domain');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
+    }
+}

--- a/tests/EPP/Frame/Command/LogoutTest.php
+++ b/tests/EPP/Frame/Command/LogoutTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Frame\Command;
+
+use AfriCC\EPP\Frame\Command\Logout;
+use PHPUnit\Framework\TestCase;
+
+class LogoutTest extends TestCase
+{
+    public function testLogoutFrame()
+    {
+        $frame = new Logout();
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <logout/>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+}

--- a/tests/EPP/Frame/Command/PollTest.php
+++ b/tests/EPP/Frame/Command/PollTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Frame\Command;
+
+use AfriCC\EPP\Frame\Command\Poll;
+use PHPUnit\Framework\TestCase;
+
+class PollTest extends TestCase
+{
+    public function testPollFrameRequest()
+    {
+        $frame = new Poll();
+        $frame->request();
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <poll op="req"/>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+
+    public function testPollFrameAck()
+    {
+        $frame = new Poll();
+        $frame->ack('msg-id-1234');
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <poll op="ack" msgID="msg-id-1234"/>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+}

--- a/tests/EPP/Frame/Command/Renew/DomainRenewTest.php
+++ b/tests/EPP/Frame/Command/Renew/DomainRenewTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Frame\Command\Renew;
+
+use AfriCC\EPP\Frame\Command\Renew\Domain;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class DomainRenewTest extends TestCase
+{
+    public function testDomainRenewFrame()
+    {
+        $frame = new Domain();
+        $frame->setDomain(TEST_DOMAIN);
+        $frame->setCurrentExpirationDate('2017-04-25');
+        $frame->setPeriod('1y');
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <renew>
+                  <domain:renew xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                    <domain:name>' . TEST_DOMAIN . '</domain:name>
+                    <domain:curExpDate>2017-04-25</domain:curExpDate>
+                    <domain:period unit="y">1</domain:period>
+                  </domain:renew>
+                </renew>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+
+    public function testDomainRenewFrameInvalidDomain()
+    {
+        $frame = new Domain();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->setDomain('invalid_domain');
+        } else {
+            try {
+                $frame->setDomain('invalid_domain');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
+    }
+}

--- a/tests/EPP/Frame/Command/Transfer/DomainTransferTest.php
+++ b/tests/EPP/Frame/Command/Transfer/DomainTransferTest.php
@@ -77,4 +77,20 @@ class DomainTransferTest extends TestCase
             }
         }
     }
+
+    public function testDomainTransferFrameInvalidOperation()
+    {
+        $frame = new Domain();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->setOperation('invalid_operation');
+        } else {
+            try {
+                $frame->setOperation('invalid_operation');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
+    }
 }

--- a/tests/EPP/Frame/Command/Transfer/DomainTransferTest.php
+++ b/tests/EPP/Frame/Command/Transfer/DomainTransferTest.php
@@ -3,11 +3,12 @@
 namespace AfriCC\Tests\EPP\Frame\Command\Transfer;
 
 use AfriCC\EPP\Frame\Command\Transfer\Domain;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 class DomainTransferTest extends TestCase
 {
-    public function testTransferDomainFrame()
+    public function testDomainTransferFrame()
     {
         $frame = new Domain();
         $frame->setOperation('cancel');
@@ -35,7 +36,7 @@ class DomainTransferTest extends TestCase
         );
     }
 
-    public function testTransferDomainQueryFrame()
+    public function testDomainTransferFrameQuery()
     {
         $frame = new Domain();
         $frame->setOperation('query');
@@ -59,5 +60,21 @@ class DomainTransferTest extends TestCase
             ',
             (string) $frame
         );
+    }
+
+    public function testDomainTransferFrameInvalidDomain()
+    {
+        $frame = new Domain();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(Exception::class);
+            $frame->setDomain('invalid_domain');
+        } else {
+            try {
+                $frame->setDomain('invalid_domain');
+            } catch (Exception $e) {
+                $this->assertEquals('Exception', get_class($e));
+            }
+        }
     }
 }

--- a/tests/EPP/Frame/ResponseTest.php
+++ b/tests/EPP/Frame/ResponseTest.php
@@ -104,8 +104,8 @@ class ResponseTest extends TestCase
         $this->assertEquals([
             'hostObj' => [
                 'ns21.yoann.mx',
-                'ns2.yoann.mx'
-            ]],
+                'ns2.yoann.mx',
+            ], ],
             $results[0]->values()
         );
 
@@ -114,7 +114,7 @@ class ResponseTest extends TestCase
                 'hostObj' => ['ns2.yoann.mx'],
             ],
             'reason' => 'A host that wants to be added is repeated',
-            '@reason' => ['lang' => 'en']
+            '@reason' => ['lang' => 'en'],
             ],
             $results[1]->extValues()
         );
@@ -179,7 +179,7 @@ class ResponseTest extends TestCase
                     '@name' => ['avail' => '0'],
                     'reason' => 'In Use',
                 ],
-            ]]],
+            ], ], ],
             $response->data()
         );
     }

--- a/tests/EPP/Frame/ResponseTest.php
+++ b/tests/EPP/Frame/ResponseTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Frame;
+
+use AfriCC\EPP\Frame\Response;
+use AfriCC\EPP\Frame\ResponseFactory;
+use AfriCC\EPP\Frame\Response\MessageQueue;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase
+{
+    public function testLegacyResponseWithoutValueOrResData()
+    {
+        $response = ResponseFactory::build(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+             <response>
+               <result code="1000">
+                 <msg lang="en">Command completed successfully</msg>
+               </result>
+               <trID>
+                 <clTRID>ABC-12345</clTRID>
+                 <svTRID>54321-XYZ</svTRID>
+               </trID>
+             </response>
+            </epp>
+            '
+        );
+
+        $this->assertTrue($response->success());
+        $this->assertEquals(1000, $response->code());
+        $this->assertEquals('Command completed successfully', $response->message());
+        $this->assertEquals('ABC-12345', $response->clientTransactionId());
+        $this->assertEquals('54321-XYZ', $response->serverTransactionId());
+        $this->assertEquals([], $response->data());
+    }
+
+    public function testLegacyMsgQ()
+    {
+        $response = ResponseFactory::build(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+             <response>
+               <result code="1000">
+                 <msg>Command completed successfully</msg>
+               </result>
+               <msgQ count="5" id="12345">
+                 <qDate>2000-06-08T22:00:00.0Z</qDate>
+                 <msg>Transfer requested.</msg>
+               </msgQ>
+               <trID>
+                 <clTRID>ABC-12345</clTRID>
+                 <svTRID>54321-XYZ</svTRID>
+               </trID>
+             </response>
+            </epp>
+            '
+        );
+
+        $this->assertInstanceOf(MessageQueue::class, $response);
+        $this->assertEquals(1000, $response->code());
+        $this->assertEquals('12345', $response->queueId());
+        $this->assertEquals(5, $response->queueCount());
+        $this->assertEquals('2000-06-08 22:00:00', $response->queueDate('Y-m-d H:i:s'));
+        $this->assertEquals('Transfer requested.', $response->queueMessage());
+    }
+
+    public function testResponse()
+    {
+        $response = ResponseFactory::build(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                <response>
+                    <result code="2303">
+                        <msg lang="fr">Object does not exist</msg>
+                        <value xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                            <domain:hostObj>ns21.yoann.mx</domain:hostObj>
+                        </value>
+                    </result>
+                    <result code="2306">
+                        <msg lang="en">Parameter value policy error</msg>
+                        <extValue>
+                            <value xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                                <domain:hostObj>ns2.yoann.mx</domain:hostObj>
+                            </value>
+                            <reason lang="en">A host that wants to be added is repeated</reason>
+                        </extValue>
+                    </result>
+                    <trID>
+                        <clTRID>rar_infos-554c07c8a541b</clTRID>
+                        <svTRID>1163276970</svTRID>
+                    </trID>
+                </response>
+            </epp>
+            '
+        );
+
+        $results = $response->results();
+
+        //var_dump($results[0]->values());
+
+        $this->assertFalse($results[0]->success());
+
+        $this->assertEquals(2303, $results[0]->code());
+        $this->assertEquals(2306, $results[1]->code());
+
+        $this->assertEquals('fr', $results[0]->messageLanguage());
+        $this->assertEquals('en', $results[1]->messageLanguage());
+
+        $this->assertEquals('Object does not exist', $results[0]->message());
+        $this->assertEquals('Parameter value policy error', $results[1]->message());
+    }
+}

--- a/tests/EPP/Frame/ResponseTest.php
+++ b/tests/EPP/Frame/ResponseTest.php
@@ -183,4 +183,25 @@ class ResponseTest extends TestCase
             $response->data()
         );
     }
+
+    public function testResponseSuccess()
+    {
+        $response = ResponseFactory::build(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+             <response>
+               <result code="1000">
+                 <msg lang="en">Command completed successfully</msg>
+               </result>
+               <trID>
+                 <clTRID>ABC-12345</clTRID>
+                 <svTRID>54321-XYZ</svTRID>
+               </trID>
+             </response>
+            </epp>
+            '
+            );
+
+        $this->assertTrue($response->results()[0]->success());
+    }
 }


### PR DESCRIPTION
This PR implements #12 as in https://tools.ietf.org/html/rfc5730#section-2.6 properly. E.g. `$response->results()` will always return an array with `Result` objects that have similar getters as legacy (e.g. `code()`, `message()`, etc.).

Additionally on or multiple `value` can be fetched in `nodeToArray` form. Most probably in future this needs to be a little more sophisticated and depend on the xml that was returned (can get complex as epp-extension will have to implement it as well)