### PR TITLE
Encode special characters as XML entities

### DIFF
--- a/src/AfriCC/EPP/AbstractFrame.php
+++ b/src/AfriCC/EPP/AbstractFrame.php
@@ -59,7 +59,7 @@ abstract class AbstractFrame extends DOMDocument implements FrameInterface
         }
 
         if ($value !== null) {
-            $this->nodes[$path]->nodeValue = $value;
+            $this->nodes[$path]->nodeValue = htmlspecialchars($value, ENT_XML1, 'UTF-8');
         }
 
         return $this->nodes[$path];

--- a/src/AfriCC/EPP/AbstractFrame.php
+++ b/src/AfriCC/EPP/AbstractFrame.php
@@ -128,7 +128,7 @@ abstract class AbstractFrame extends DOMDocument implements FrameInterface
                 $node_name = $matches[1];
             }
             // check if attribute needs to be set
-            elseif (preg_match('/^(.*)\[@([a-z0-9]+)=\'([a-z0-9]+)\'\]$/i', $node_name, $matches)) {
+            elseif (preg_match('/^(.*)\[@([a-z0-9]+)=\'([a-z0-9_]+)\'\]$/i', $node_name, $matches)) {
                 $node_name = $matches[1];
                 $attr_name = $matches[2];
                 $attr_value = $matches[3];

--- a/src/AfriCC/EPP/Validator.php
+++ b/src/AfriCC/EPP/Validator.php
@@ -328,7 +328,7 @@ class Validator
             return false;
         }
 
-        $ascii_email = substr($email, 0, $pos) . '@' . idn_to_ascii(substr($email, $pos + 1), 0, INTL_IDNA_VARIANT_2003);
+        $ascii_email = substr($email, 0, $pos) . '@' . idn_to_ascii(substr($email, $pos + 1), 0, INTL_IDNA_VARIANT_UTS46);
 
         return (bool) filter_var($ascii_email, FILTER_VALIDATE_EMAIL);
     }


### PR DESCRIPTION
Sending EPP request containing special characters like '&' causes errors. This should fix it by encoding special characters as XML entities. Is it OK?