### PR TITLE
Adds bin2hex optional to random auth key.

### DIFF
--- a/src/AfriCC/EPP/Random.php
+++ b/src/AfriCC/EPP/Random.php
@@ -41,7 +41,7 @@ class Random
      *
      * @return string
      */
-    public static function auth($len)
+    public static function auth($len, $hex = '')
     {
         if (function_exists('random_bytes')) {
             $randomBytes = random_bytes($len);
@@ -51,7 +51,11 @@ class Random
             $randomBytes = mcrypt_create_iv($len, MCRYPT_DEV_URANDOM);
         }
 
-        $randomBytes = base64_encode($randomBytes);
+        if (TRUE == $hex) {
+            $randomBytes = bin2hex($randomBytes);
+        } else {
+            $randomBytes = base64_encode($randomBytes);
+        }
 
         return substr(rtrim($randomBytes, '='), 0, $len);
     }


### PR DESCRIPTION
This is a non-breaking change.

The function can be called exactly as
previously with no changes to functionality.

The addition of the optional second parameter as TRUE simply converts
the paramater $randomBytes to hex instead of base64 encoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/africc/php-epp2/55)
<!-- Reviewable:end -->
