### PR TITLE
Add Nominet release extension

### DIFF
--- a/src/AfriCC/EPP/Extension/Nominet/Release/Domain.php
+++ b/src/AfriCC/EPP/Extension/Nominet/Release/Domain.php
@@ -11,8 +11,8 @@
 
 namespace App\EPP\Extension\Nominet\Release;
 
-use AfriCC\EPP\Frame\Command\Update as UpdateCommand;
 use AfriCC\EPP\ExtensionInterface as Extension;
+use AfriCC\EPP\Frame\Command\Update as UpdateCommand;
 use AfriCC\EPP\Validator;
 use Exception;
 

--- a/src/AfriCC/EPP/Extension/Nominet/Release/Domain.php
+++ b/src/AfriCC/EPP/Extension/Nominet/Release/Domain.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the php-epp2 library.
+ *
+ * (c) Gunter Grodotzki <gunter@afri.cc>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace App\EPP\Extension\Nominet\Release;
+
+use AfriCC\EPP\Frame\Command\Update as UpdateCommand;
+use AfriCC\EPP\ExtensionInterface as Extension;
+use AfriCC\EPP\Validator;
+use Exception;
+
+/**
+ * @see https://registrars.nominet.uk/namespace/uk/registration-and-domain-management/epp-commands#release
+ */
+class Domain extends UpdateCommand implements Extension
+{
+    protected $extension = 'r';
+    protected $extension_xmlns = 'http://www.nominet.org.uk/epp/xml/std-release-1.0';
+
+    public function setDomain($domain)
+    {
+        if (!Validator::isHostname($domain)) {
+            throw new Exception(sprintf('%s is not a valid domain name', $domain));
+        }
+
+        $this->set('//epp:epp/epp:command/epp:update/r:release/r:domainName', $domain);
+    }
+
+    public function setRegistrarTag($tag)
+    {
+        $this->set('//epp:epp/epp:command/epp:update/r:release/r:registrarTag', $tag);
+    }
+
+    public function getExtensionNamespace()
+    {
+        return $this->extension_xmlns;
+    }
+}

--- a/tests/EPP/Extension/Nominet/Release/DomainTest.php
+++ b/tests/EPP/Extension/Nominet/Release/DomainTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AfriCC\Tests\EPP\Extension\Nominet\Release;
+
+use AfriCC\EPP\Extension\Nominet\Release\Domain as DomainRelease;
+use PHPUnit\Framework\TestCase;
+
+class DomainTest extends TestCase
+{
+    public function test()
+    {
+        $tag = 'EXAMPLE-TAG';
+
+        $frame = new DomainRelease;
+        $frame->setDomain(TEST_DOMAIN);
+        $frame->setRegistrarTag('EXAMPLE-TAG');
+
+        $this->assertXmlStringEqualsXmlString(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+              <command>
+                <update>
+                  <r:release xmlns:r="http://www.nominet.org.uk/epp/xml/std-release-1.0">
+                    <r:domainName>' . TEST_DOMAIN . '</r:domainName>
+                    <r:registrarTag>' . $tag . '</r:registrarTag>
+                  </r:release>
+                </update>
+              </command>
+            </epp>
+            ',
+            (string) $frame
+        );
+    }
+}

--- a/tests/EPP/Extension/Nominet/Release/DomainTest.php
+++ b/tests/EPP/Extension/Nominet/Release/DomainTest.php
@@ -11,7 +11,7 @@ class DomainTest extends TestCase
     {
         $tag = 'EXAMPLE-TAG';
 
-        $frame = new DomainRelease;
+        $frame = new DomainRelease();
         $frame->setDomain(TEST_DOMAIN);
         $frame->setRegistrarTag('EXAMPLE-TAG');
 


### PR DESCRIPTION
Adds Nominet's release command as an extension.

See docs: 
https://registrars.nominet.uk/namespace/uk/registration-and-domain-management/epp-commands#release