### PR TITLE
Fixed poor logic which prevents verify_peer_name from being set to false

### DIFF
--- a/src/AfriCC/EPP/Client.php
+++ b/src/AfriCC/EPP/Client.php
@@ -40,7 +40,7 @@ class Client extends AbstractClient implements ClientInterface
         }
 
         if (isset($config['verify_peer_name'])) {
-            $this->verify_peer_name = (bool)$config['verify_peer_name'];
+            $this->verify_peer_name = (bool) $config['verify_peer_name'];
         } else {
             $this->verify_peer_name = true;
         }

--- a/src/AfriCC/EPP/Client.php
+++ b/src/AfriCC/EPP/Client.php
@@ -39,7 +39,7 @@ class Client extends AbstractClient implements ClientInterface
             $this->chunk_size = 1024;
         }
 
-        if (isset($config['verify_peer_name'])) {
+        if (isset($config['verify_peer_name'])) {
             $this->verify_peer_name = (bool) $config['verify_peer_name'];
         } else {
             $this->verify_peer_name = true;

--- a/src/AfriCC/EPP/Client.php
+++ b/src/AfriCC/EPP/Client.php
@@ -39,8 +39,8 @@ class Client extends AbstractClient implements ClientInterface
             $this->chunk_size = 1024;
         }
 
-        if (!empty($config['verify_peer_name'])) {
-            $this->verify_peer_name = (bool) $config['verify_peer_name'];
+        if (isset($config['verify_peer_name'])) {
+            $this->verify_peer_name = (bool)$config['verify_peer_name'];
         } else {
             $this->verify_peer_name = true;
         }


### PR DESCRIPTION
empty() considers false to be empty, so it was not possible to set verify_peer_name to false as was changed to true due to the check.

See: http://php.net/manual/en/function.empty.php

isset() should be used here to ensure the option is taken into account when set.
