### PR TITLE
Set trusty for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - php: 7.0
     - php: 5.6
     - php: 5.5
+      dist: trusty
 
 sudo: false
 


### PR DESCRIPTION
#80 

Edit travis.yml to use Ubuntu Trusty and not let the tests fail

```
    - php: 5.5
      dist: trusty
```