### PR TITLE
Allow login/eppver specification in client autologin

### DIFF
--- a/src/AfriCC/EPP/AbstractClient.php
+++ b/src/AfriCC/EPP/AbstractClient.php
@@ -131,6 +131,7 @@ abstract class AbstractClient implements ClientInterface
      * @param array $config
      * @param string $key
      * @param mixed $default
+     *
      * @return mixed
      */
     protected function getConfigDefault(array $config, string $key, $default = null)
@@ -138,6 +139,7 @@ abstract class AbstractClient implements ClientInterface
         if (!empty($config[$key])) {
             return $config[$key];
         }
+
         return $default;
     }
 
@@ -149,7 +151,9 @@ abstract class AbstractClient implements ClientInterface
      * @param array $config
      * @param string $key
      * @param mixed $default
+     *
      * @return mixed
+     *
      * @see AbstractClient::getConfigDefault
      */
     protected function getConfigDefaultBool(array $config, string $key, $default = null)
@@ -157,6 +161,7 @@ abstract class AbstractClient implements ClientInterface
         if (!empty($config[$key]) && is_bool($config[$key])) {
             return $config[$key];
         }
+
         return $default;
     }
 
@@ -168,7 +173,9 @@ abstract class AbstractClient implements ClientInterface
      * @param array $config
      * @param string $key
      * @param mixed $default
+     *
      * @return mixed
+     *
      * @see AbstractClient::getConfigDefault
      */
     protected function getConfigDefaultArray(array $config, string $key, $default = null)
@@ -176,6 +183,7 @@ abstract class AbstractClient implements ClientInterface
         if (!empty($config[$key]) && is_array($config[$key])) {
             return $config[$key];
         }
+
         return $default;
     }
 
@@ -187,8 +195,11 @@ abstract class AbstractClient implements ClientInterface
      * @param array $config
      * @param string $key
      * @param mixed $default
-     * @return mixed
+     *
      * @throws Exception in case file is specified but not readable
+     *
+     * @return mixed
+     *
      * @see AbstractClient::getConfigDefault
      */
     protected function getConfigDefaultReadableFile(array $config, string $key, $default = null)
@@ -197,10 +208,12 @@ abstract class AbstractClient implements ClientInterface
             $return = (string) $config[$key];
 
             if (!is_readable($return)) {
-                throw new \Exception(sprintf('unable to read %s: %s',$key, $return));
+                throw new \Exception(sprintf('unable to read %s: %s', $key, $return));
             }
+
             return $return;
         }
+
         return $default;
     }
 

--- a/src/AfriCC/EPP/AbstractClient.php
+++ b/src/AfriCC/EPP/AbstractClient.php
@@ -100,7 +100,7 @@ abstract class AbstractClient implements ClientInterface
         $this->prepareCredentials($config);
         $this->prepareSSLOptions($config);
         $this->prepareEPPServices($config);
-        $this->prepareEPPVersionLang($lang);
+        $this->prepareEPPVersionLang($config);
     }
 
     /**

--- a/src/AfriCC/EPP/Client.php
+++ b/src/AfriCC/EPP/Client.php
@@ -32,22 +32,11 @@ class Client extends AbstractClient implements ClientInterface
     {
         parent::__construct($config, $objectSpec);
 
-        if (!empty($config['chunk_size'])) {
-            $this->chunk_size = (int) $config['chunk_size'];
-        } else {
-            $this->chunk_size = 1024;
-        }
+        $this->chunk_size = (int) $this->getConfigDefault($config, 'chunk_size', 1024);
+        $this->verify_peer_name = $this->getConfigDefaultBool($config, 'verify_peer_name', true);
 
-        if (isset($config['verify_peer_name'])) {
-            $this->verify_peer_name = (bool) $config['verify_peer_name'];
-        } else {
-            $this->verify_peer_name = true;
-        }
-
-        if ($this->port === false) {
-            // if not set, default port is 700
-            $this->port = 700;
-        }
+        // override 'port' default to false from AbstractClient::prepareConnectionOptions
+        $this->port = (int) $this->getConfigDefault($config, 'port', 700);
     }
 
     public function __destruct()

--- a/src/AfriCC/EPP/HTTPClient.php
+++ b/src/AfriCC/EPP/HTTPClient.php
@@ -33,11 +33,7 @@ class HTTPClient extends AbstractClient implements ClientInterface
 
     protected function prepareCookieJar(array $config)
     {
-        if (!empty($config['cookiejar'])) {
-            $this->cookiejar = $config['cookiejar'];
-        } else {
-            $this->cookiejar = tempnam(sys_get_temp_dir(), 'ehc');
-        }
+        $this->cookiejar = $this->getConfigDefault($config, 'cookiejar', tempnam(sys_get_temp_dir(), 'ehc'));
 
         if (!is_readable($this->cookiejar) || !is_writable($this->cookiejar)) {
             throw new \Exception(


### PR DESCRIPTION
Introduce 4 new methods to simplify AbstractClient and it's implementations
add 2 new options: `lang` and `version`, passed to automatic login to client

This came to me when replying to #22 :smile: 