### PR TITLE
FIX: getConfigDefaultBool() return always default value

### DIFF
--- a/src/AfriCC/EPP/AbstractClient.php
+++ b/src/AfriCC/EPP/AbstractClient.php
@@ -158,7 +158,7 @@ abstract class AbstractClient implements ClientInterface
      */
     protected function getConfigDefaultBool(array $config, string $key, $default = null)
     {
-        if (!empty($config[$key]) && is_bool($config[$key])) {
+        if (isset($config[$key]) && is_bool($config[$key])) {
             return $config[$key];
         }
 


### PR DESCRIPTION
After merging PR #86 for boolvar used `empty()` intend `isset()`.